### PR TITLE
Fix Sphinx packet plaintext format as per the spec

### DIFF
--- a/crypto/block/block.go
+++ b/crypto/block/block.go
@@ -24,15 +24,16 @@ import (
 	"io"
 
 	"github.com/katzenpost/client/constants"
-	coreConstants "github.com/katzenpost/core/constants"
+	coreconstants "github.com/katzenpost/core/constants"
 	"github.com/katzenpost/core/crypto/ecdh"
+	"github.com/katzenpost/core/sphinx"
 	"github.com/katzenpost/core/utils"
 	"github.com/katzenpost/noise"
 )
 
 const (
 	// BlockLength is the maximum payload size of a Block in bytes.
-	BlockLength         = coreConstants.ForwardPayloadLength - (blockCipherOverhead + blockOverhead)
+	BlockLength         = coreconstants.ForwardPayloadLength - (blockCipherOverhead + blockOverhead) - (coreconstants.SphinxPlaintextHeaderLength + sphinx.SURBLength)
 	blockCipherOverhead = keyLen + macLen + keyLen + macLen // -> e, es, s, ss
 	blockOverhead       = 24
 

--- a/crypto/block/block_test.go
+++ b/crypto/block/block_test.go
@@ -23,11 +23,16 @@ import (
 
 	"github.com/katzenpost/core/constants"
 	"github.com/katzenpost/core/crypto/ecdh"
+	"github.com/katzenpost/core/sphinx"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBlock(t *testing.T) {
 	require := require.New(t)
+
+	const (
+		hdrLength = constants.SphinxPlaintextHeaderLength + sphinx.SURBLength
+	)
 
 	idKeyAlice, err := ecdh.NewKeypair(rand.Reader)
 	require.NoError(err, "Block: Alice NewKeypair()")
@@ -53,7 +58,7 @@ func TestBlock(t *testing.T) {
 		blkA.Block = payload[:sz]
 		ct, err := hAlice.Encrypt(idKeyBob.PublicKey(), blkA)
 		require.NoError(err, "Block encrypt failure")
-		require.Len(ct, constants.ForwardPayloadLength)
+		require.Equal(len(ct), constants.ForwardPayloadLength-hdrLength)
 
 		// Decrypt.
 		blk, peerPk, err := hBob.Decrypt(ct)

--- a/proxy/send_test.go
+++ b/proxy/send_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/katzenpost/client/path_selection"
 	"github.com/katzenpost/client/session_pool"
 	"github.com/katzenpost/client/storage"
+	coreconstants "github.com/katzenpost/core/constants"
 	"github.com/katzenpost/core/crypto/ecdh"
 	"github.com/katzenpost/core/crypto/rand"
 	"github.com/katzenpost/core/epochtime"
@@ -319,6 +320,13 @@ func decryptSphinxLayers(t *testing.T, require *require.Assertions, sphinxPacket
 func TestSender(t *testing.T) {
 	require := require.New(t)
 
+	const (
+		hdrLength    = coreconstants.SphinxPlaintextHeaderLength + sphinx.SURBLength
+		flagsPadding = 0
+		flagsSURB    = 1
+		reserved     = 0
+	)
+
 	mixPKI, keysMap := newMixPKI(require)
 	nrHops := 5
 	lambda := float64(.123)
@@ -388,7 +396,7 @@ func TestSender(t *testing.T) {
 	bobsCiphertext, err := decryptSphinxLayers(t, require, sendPacket.SphinxPacket, aliceProviderKey, bobProviderKey, keysMap, nrHops)
 	require.NoError(err, "handler decrypt sphinx layers failure")
 	//bobSurb := bobsCiphertext[:556] // used for reply SURB ACK
-	b, _, err := bobBlockHandler.Decrypt(bobsCiphertext[556:])
+	b, _, err := bobBlockHandler.Decrypt(bobsCiphertext[hdrLength:])
 	require.NoError(err, "handler decrypt failure")
 	t.Logf("block: %s", string(b.Block))
 


### PR DESCRIPTION
i need to fix some of the tests that are currently mocking mixnet decryption and instead write integration tests that use katzenpost/server code.