### PR TITLE
Send the 3 types of Loopix traffic

### DIFF
--- a/multispool/spool.go
+++ b/multispool/spool.go
@@ -1,0 +1,134 @@
+// spool.go - remote spool operations
+// Copyright (C) 2019  David Stainton.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package multispool
+
+import (
+	"github.com/katzenpost/core/crypto/eddsa"
+	"github.com/ugorji/go/codec"
+)
+
+const (
+	SpoolIDSize   = 12
+	SignatureSize = 64
+	PublicKeySize = 32
+	MessageIDSize = 4
+
+	CreateSpoolCommand     = 0
+	PurgeSpoolCommand      = 1
+	AppendMessageCommand   = 2
+	RetrieveMessageCommand = 3
+)
+
+var (
+	cborHandle *codec.CborHandle
+)
+
+type SpoolRequest struct {
+	Command   int                 `cbor:"command"`
+	SpoolID   [SpoolIDSize]byte   `cbor:"spool_id"`
+	Signature [SignatureSize]byte `cbor:"signature"`
+	PublicKey [PublicKeySize]byte `cbor:"public_key"`
+	MessageID [MessageIDSize]byte `cbor:"message_id"`
+	Message   []byte              `cbor:"message"`
+}
+
+func SpoolRequestFromBytes(raw []byte) (SpoolRequest, error) {
+	s := SpoolRequest{}
+	dec := codec.NewDecoderBytes(raw, cborHandle)
+	err := dec.Decode(&s)
+	return s, err
+}
+
+func (s *SpoolRequest) Encode() ([]byte, error) {
+	out := []byte{}
+	enc := codec.NewEncoderBytes(&out, cborHandle)
+	err := enc.Encode(s)
+	return out, err
+}
+
+type SpoolResponse struct {
+	SpoolID [SpoolIDSize]byte `cbor:"spool_id"`
+	Message []byte            `cbor:"message"`
+	Status  string            `cbor:"status"`
+}
+
+func SpoolResponseFromBytes(raw []byte) (SpoolResponse, error) {
+	s := SpoolResponse{}
+	dec := codec.NewDecoderBytes(raw, cborHandle)
+	err := dec.Decode(&s)
+	return s, err
+}
+
+func (s *SpoolResponse) Encode() ([]byte, error) {
+	out := []byte{}
+	enc := codec.NewEncoderBytes(&out, cborHandle)
+	err := enc.Encode(s)
+	return out, err
+}
+
+func CreateSpool(privKey *eddsa.PrivateKey) ([]byte, error) {
+	signature := privKey.Sign(privKey.PublicKey().Bytes())
+	pubArray := [PublicKeySize]byte{}
+	sigArray := [SignatureSize]byte{}
+	copy(pubArray[:], privKey.PublicKey().Bytes())
+	copy(sigArray[:], signature)
+	s := SpoolRequest{
+		Command:   CreateSpoolCommand,
+		PublicKey: pubArray,
+		Signature: sigArray,
+	}
+	return s.Encode()
+}
+
+func PurgeSpool(spoolID [SpoolIDSize]byte, privKey *eddsa.PrivateKey) ([]byte, error) {
+	signature := privKey.Sign(privKey.PublicKey().Bytes())
+	pubArray := [PublicKeySize]byte{}
+	sigArray := [SignatureSize]byte{}
+	copy(pubArray[:], privKey.PublicKey().Bytes())
+	copy(sigArray[:], signature)
+	s := SpoolRequest{
+		Command:   PurgeSpoolCommand,
+		PublicKey: pubArray,
+		Signature: sigArray,
+		SpoolID:   spoolID,
+	}
+	return s.Encode()
+}
+
+func AppendToSpool(spoolID [SpoolIDSize]byte, message []byte) ([]byte, error) {
+	s := SpoolRequest{
+		Command: AppendMessageCommand,
+		SpoolID: spoolID,
+		Message: message,
+	}
+	return s.Encode()
+}
+
+func ReadFromSpool(spoolID [SpoolIDSize]byte, messageID [MessageIDSize]byte, privKey *eddsa.PrivateKey) ([]byte, error) {
+	signature := privKey.Sign(privKey.PublicKey().Bytes())
+	pubArray := [PublicKeySize]byte{}
+	sigArray := [SignatureSize]byte{}
+	copy(pubArray[:], privKey.PublicKey().Bytes())
+	copy(sigArray[:], signature)
+	s := SpoolRequest{
+		Command:   RetrieveMessageCommand,
+		PublicKey: pubArray,
+		Signature: sigArray,
+		SpoolID:   spoolID,
+	}
+	return s.Encode()
+}

--- a/session/session.go
+++ b/session/session.go
@@ -64,6 +64,8 @@ type Session struct {
 	// popping items off our send egress FIFO queue. If the queue is ever
 	// empty we send a decoy loop message.
 	pTimer *poisson.Fount
+	dTimer *poisson.Fount
+	lTimer *poisson.Fount
 
 	linkKey   *ecdh.PrivateKey
 	opCh      chan workerOp

--- a/session/session.go
+++ b/session/session.go
@@ -57,14 +57,14 @@ type Session struct {
 	haltedCh   chan interface{}
 	haltOnce   sync.Once
 
-	// XXX Our client scheduler is different than specified in
-	// "The Loopix Anonymity System".
-	//
 	// We use λP a poisson process to control the interval between
 	// popping items off our send egress FIFO queue. If the queue is ever
 	// empty we send a decoy loop message.
+	// λP
 	pTimer *poisson.Fount
+	// λD
 	dTimer *poisson.Fount
+	// λL
 	lTimer *poisson.Fount
 
 	linkKey   *ecdh.PrivateKey


### PR DESCRIPTION
as per our recent design discussions, the client really does need to use all three types of Loopix decoy traffic. this change also must match the new fields added in this branch of core:

https://github.com/katzenpost/core/pull/75