### PR TITLE
Use an event channel for reply notifications

### DIFF
--- a/session/event.go
+++ b/session/event.go
@@ -1,0 +1,87 @@
+// event.go - mixnet client session events
+// Copyright (C) 2018, 2019  Yawning Angel and David Stainton.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package session
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	cConstants "github.com/katzenpost/client/constants"
+)
+
+// Event is the generic event sent over the event listener channel.
+type Event interface {
+	// String returns a string representation of the Event.
+	String() string
+}
+
+// ConnectionStatusEvent is the event sent when an account's connection status
+// changes.
+type ConnectionStatusEvent struct {
+	// IsConnected is true iff the account is connected to the provider.
+	IsConnected bool
+
+	// Err is the error encountered when connecting or by the connection if any.
+	Err error
+}
+
+// String returns a string representation of the ConnectionStatusEvent.
+func (e *ConnectionStatusEvent) String() string {
+	if !e.IsConnected {
+		return fmt.Sprintf("ConnectionStatus: %v (%v)", e.IsConnected, e.Err)
+	}
+	return fmt.Sprintf("ConnectionStatus: %v", e.IsConnected)
+}
+
+// MessageReplyEvent is the event sent when a new message is received.
+type MessageReplyEvent struct {
+	// MessageID is the unique identifier for the request associated with the
+	// reply.
+	MessageID *[cConstants.MessageIDLength]byte
+
+	// Payload is the reply payload if any.
+	Payload []byte
+
+	// Err is the error encountered when servicing the request if any.
+	Err error
+}
+
+// String returns a string representation of the MessageReplyEvent.
+func (e *MessageReplyEvent) String() string {
+	if e.Err != nil {
+		return fmt.Sprintf("MessageReply: %v failed: %v", hex.EncodeToString(e.MessageID[:]), e.Err)
+	}
+	return fmt.Sprintf("KaetzchenReply: %v (%v bytes)", hex.EncodeToString(e.MessageID[:]), len(e.Payload))
+}
+
+// MessageSentEvent is the event sent when a message has been fully transmitted.
+type MessageSentEvent struct {
+	// MessageID is the local unique identifier for the message, generated
+	// when the message was enqueued.
+	MessageID []byte
+
+	// Err is the error encountered when sending the message if any.
+	Err error
+}
+
+// String returns a string representation of a MessageSentEvent.
+func (e *MessageSentEvent) String() string {
+	if e.Err != nil {
+		return fmt.Sprintf("MessageSent: %v failed: %v", hex.EncodeToString(e.MessageID), e.Err)
+	}
+	return fmt.Sprintf("MessageSent: %v", hex.EncodeToString(e.MessageID))
+}

--- a/session/event.go
+++ b/session/event.go
@@ -72,7 +72,7 @@ func (e *MessageReplyEvent) String() string {
 type MessageSentEvent struct {
 	// MessageID is the local unique identifier for the message, generated
 	// when the message was enqueued.
-	MessageID []byte
+	MessageID *[cConstants.MessageIDLength]byte
 
 	// Err is the error encountered when sending the message if any.
 	Err error
@@ -81,7 +81,7 @@ type MessageSentEvent struct {
 // String returns a string representation of a MessageSentEvent.
 func (e *MessageSentEvent) String() string {
 	if e.Err != nil {
-		return fmt.Sprintf("MessageSent: %v failed: %v", hex.EncodeToString(e.MessageID), e.Err)
+		return fmt.Sprintf("MessageSent: %v failed: %v", hex.EncodeToString(e.MessageID[:]), e.Err)
 	}
-	return fmt.Sprintf("MessageSent: %v", hex.EncodeToString(e.MessageID))
+	return fmt.Sprintf("MessageSent: %v", hex.EncodeToString(e.MessageID[:]))
 }

--- a/session/remote_spool.go
+++ b/session/remote_spool.go
@@ -27,7 +27,7 @@ func (s *Session) SendCreateSpool(privKey *eddsa.PrivateKey, recipient, provider
 	if err != nil {
 		return err
 	}
-	_, err = s.SendUnreliableQuery(recipient, provider, cmd)
+	_, err = s.SendUnreliableMessage(recipient, provider, cmd)
 	if err != nil {
 		return err
 	}

--- a/session/send.go
+++ b/session/send.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	RoundTripTimeSlop time.Duration = 30 * time.Second
+	RoundTripTimeSlop time.Duration = 88 * time.Second
 )
 
 // Message is a message reference which is used to match future
@@ -76,6 +76,7 @@ type Message struct {
 }
 
 func (s *Session) WaitForSent(msgId *[cConstants.MessageIDLength]byte) error {
+	s.log.Debug("Waiting for message to be sent.")
 	s.mapLock.Lock()
 	msg, ok := s.messageIDMap[*msgId]
 	if !ok {
@@ -90,6 +91,7 @@ func (s *Session) WaitForSent(msgId *[cConstants.MessageIDLength]byte) error {
 	}
 	s.mapLock.Unlock()
 	<-waitCh.Out()
+	s.log.Debug("Finished waiting. Message was sent.")
 	return nil
 }
 
@@ -166,11 +168,11 @@ func (s *Session) doSend(msg *Message) error {
 		msg.Sent = true
 		msg.ReplyETA = eta
 		s.mapLock.Lock()
-		defer s.mapLock.Unlock()
 		s.surbIDMap[surbID] = msg
+		s.mapLock.Unlock()
 	}
 	s.eventCh.In() <- &MessageSentEvent{
-		MessageID: msg.ID[:],
+		MessageID: msg.ID,
 		Err:       nil,
 	}
 	return err

--- a/session/send.go
+++ b/session/send.go
@@ -32,11 +32,13 @@ const (
 	RoundTripTimeSlop time.Duration = 88 * time.Second
 )
 
+type MessageID *[cConstants.MessageIDLength]byte
+
 // Message is a message reference which is used to match future
 // received SURB replies.
 type Message struct {
 	// ID is the message identifier
-	ID *[cConstants.MessageIDLength]byte
+	ID MessageID
 
 	// Recipient is the message recipient
 	Recipient string
@@ -75,7 +77,7 @@ type Message struct {
 	IsDecoy bool
 }
 
-func (s *Session) WaitForSent(msgId *[cConstants.MessageIDLength]byte) error {
+func (s *Session) WaitForSent(msgId MessageID) error {
 	s.log.Debug("Waiting for message to be sent.")
 	s.mapLock.Lock()
 	msg, ok := s.messageIDMap[*msgId]
@@ -100,7 +102,7 @@ func (s *Session) WaitForSent(msgId *[cConstants.MessageIDLength]byte) error {
 }
 
 // WaitForReply blocks until a reply is received.
-func (s *Session) WaitForReply(msgId *[cConstants.MessageIDLength]byte) ([]byte, error) {
+func (s *Session) WaitForReply(msgId MessageID) ([]byte, error) {
 	s.log.Debugf("WaitForReply message ID: %x\n", *msgId)
 	err := s.WaitForSent(msgId)
 	if err != nil {

--- a/session/session.go
+++ b/session/session.go
@@ -74,11 +74,12 @@ type Session struct {
 	egressQueue     EgressQueue
 	egressQueueLock *sync.Mutex
 
-	eventCh      channels.Channel
-	waitChans    map[[sConstants.SURBIDLength]byte]channels.Channel
-	surbIDMap    map[[sConstants.SURBIDLength]byte]*Message
-	messageIDMap map[[cConstants.MessageIDLength]byte]*Message
-	mapLock      *sync.Mutex
+	eventCh       channels.Channel
+	waitSentChans map[[cConstants.MessageIDLength]byte]channels.Channel
+	waitChans     map[[cConstants.MessageIDLength]byte]channels.Channel
+	surbIDMap     map[[sConstants.SURBIDLength]byte]*Message
+	messageIDMap  map[[cConstants.MessageIDLength]byte]*Message
+	mapLock       *sync.Mutex
 
 	decoyLoopTally uint64
 }
@@ -106,13 +107,14 @@ func New(ctx context.Context, fatalErrCh chan error, logBackend *log.Backend, cf
 	log := logBackend.GetLogger(fmt.Sprintf("%s@%s_c", cfg.Account.User, cfg.Account.Provider))
 
 	s := &Session{
-		cfg:        cfg,
-		pkiClient:  pkiClient,
-		log:        log,
-		fatalErrCh: fatalErrCh,
-		opCh:       make(chan workerOp),
-		eventCh:    channels.NewInfiniteChannel(),
-		waitChans:  make(map[[sConstants.SURBIDLength]byte]channels.Channel),
+		cfg:           cfg,
+		pkiClient:     pkiClient,
+		log:           log,
+		fatalErrCh:    fatalErrCh,
+		opCh:          make(chan workerOp),
+		eventCh:       channels.NewInfiniteChannel(),
+		waitChans:     make(map[[sConstants.SURBIDLength]byte]channels.Channel),
+		waitSentChans: make(map[[cConstants.MessageIDLength]byte]channels.Channel),
 	}
 
 	// XXX todo: replace all this with persistent data store

--- a/session/session.go
+++ b/session/session.go
@@ -149,7 +149,7 @@ func New(ctx context.Context, fatalErrCh chan error, logBackend *log.Backend, cf
 		OnACKFn:             s.onACK,
 		OnDocumentFn:        s.onDocument,
 		DialContextFn:       proxyCfg.ToDialContext("authority"),
-		MessagePollInterval: time.Duration(cfg.Debug.PollingInterval) * time.Second,
+		MessagePollInterval: 1 * time.Second,
 		EnableTimeSync:      false, // Be explicit about it.
 	}
 

--- a/session/worker.go
+++ b/session/worker.go
@@ -38,13 +38,9 @@ type opNewDocument struct {
 }
 
 func (s *Session) setPollingInterval(doc *pki.Document) {
-	// Clients have 3 poisson processes:
-	// doc.LambdaP
-	// doc.LambdaL
-	// doc.LambdaD
+	// Clients have 3 poisson processes, λP, λL and, λD.
 	// However only LambdaP and LambdaL result in SURB replies.
 	interval := time.Duration(doc.LambdaP+doc.LambdaL) * time.Millisecond
-	// XXX Correct?
 	s.minclient.SetPollInterval(interval)
 }
 


### PR DESCRIPTION
What do you think? This is what mailproxy does... although notice that I chain the channels together in the event channel worker's select. Here we get the benefit of a per message blocking api... with a timeout.