### PR TITLE
Fix polling interval to config setting

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -92,7 +92,7 @@ type Debug struct {
 	CaseSensitiveUserIdentifiers bool
 
 	// PollingInterval is the interval in seconds that will be used to
-	// poll the receive queue.  By default this is 30 seconds.  Reducing
+	// poll the receive queue.  By default this is 10 seconds.  Reducing
 	// the value too far WILL result in unnecessary Provider load, and
 	// increasing the value too far WILL adversely affect large message
 	// transmit performance.

--- a/session.go
+++ b/session.go
@@ -122,7 +122,7 @@ func NewSession(
 		OnDocumentFn:        s.onDocument,
 		DialContextFn:       proxyCfg.ToDialContext("authority"),
 		PreferedTransports:  cfg.Debug.PreferedTransports,
-		MessagePollInterval: 1 * time.Second,
+		MessagePollInterval: time.Duration(cfg.Debug.PollingInterval) * time.Second,
 		EnableTimeSync:      false, // Be explicit about it.
 	}
 

--- a/worker.go
+++ b/worker.go
@@ -36,13 +36,6 @@ type opNewDocument struct {
 	doc *pki.Document
 }
 
-func (s *Session) setPollingInterval(doc *pki.Document) {
-	// Clients have 2 poisson processes, λP and λL.
-	// They result in SURB replies.
-	interval := time.Duration(doc.LambdaP+doc.LambdaL) * time.Millisecond
-	s.minclient.SetPollInterval(interval)
-}
-
 func (s *Session) connStatusChange(op opConnStatusChanged) bool {
 	isConnected := op.isConnected
 	if isConnected {
@@ -121,7 +114,6 @@ func (s *Session) worker() {
 				}
 				isConnected = newConnectedStatus
 			case opNewDocument:
-				s.setPollingInterval(op.doc)
 				err := s.isDocValid(op.doc)
 				if err != nil {
 					s.fatalErrCh <- err


### PR DESCRIPTION
and remove stupid code that made it dynamic based
on pki doc.

config polling interval defaults to 10 seconds.
can be changed in debug section of config if desired.